### PR TITLE
Update ghttp_middleware_tracing.go

### DIFF
--- a/net/ghttp/ghttp_middleware_tracing.go
+++ b/net/ghttp/ghttp_middleware_tracing.go
@@ -97,7 +97,7 @@ func internalMiddlewareServerTracing(r *Request) {
 		attribute.String(tracingEventHttpRequestUrl, r.URL.String()),
 		attribute.String(tracingEventHttpRequestHeaders, gconv.String(httputil.HeaderToMap(r.Header))),
 		attribute.String(tracingEventHttpRequestBaggage, gtrace.GetBaggageMap(ctx).String()),
-		attribute.String(tracingEventHttpRequestBody, gstr.StrLimit(
+		attribute.String(tracingEventHttpRequestBody, gstr.StrLimitRune(
 			string(reqBodyContentBytes),
 			gtrace.MaxContentLogSize(),
 			"...",
@@ -112,7 +112,7 @@ func internalMiddlewareServerTracing(r *Request) {
 		span.SetStatus(codes.Error, fmt.Sprintf(`%+v`, err))
 	}
 	// Response content logging.
-	var resBodyContent = gstr.StrLimit(r.Response.BufferString(), gtrace.MaxContentLogSize(), "...")
+	var resBodyContent = gstr.StrLimitRune(r.Response.BufferString(), gtrace.MaxContentLogSize(), "...")
 	if gzipAccepted(r.Response.Header()) {
 		reader, err := gzip.NewReader(strings.NewReader(r.Response.BufferString()))
 		if err != nil {
@@ -123,7 +123,7 @@ func internalMiddlewareServerTracing(r *Request) {
 		if err != nil {
 			span.SetStatus(codes.Error, fmt.Sprintf(`get uncompress value err:%+v`, err))
 		}
-		resBodyContent = gstr.StrLimit(string(uncompressed), gtrace.MaxContentLogSize(), "...")
+		resBodyContent = gstr.StrLimitRune(string(uncompressed), gtrace.MaxContentLogSize(), "...")
 	}
 
 	span.AddEvent(tracingEventHttpResponse, trace.WithAttributes(


### PR DESCRIPTION
gf opel auto report when body more than tracingMaxContentLogSize fail:

**** 
grpc: 
traces export: rpc error: code = Internal desc = grpc: error while marshaling: string field contains invalid UTF-8
http:
traces export: string field contains invalid UTF-8 
